### PR TITLE
Renamed 'EMAIL RECIPIENTS' env variable to 'THEMIS_EMAIL_RECIPIENTS'.…

### DIFF
--- a/.github/workflows/testing-themis.yml
+++ b/.github/workflows/testing-themis.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Test with pytest
       env:
         SENDGRID_API_KEY: ${{ secrets.SENDGRID_API_KEY }}
-        EMAIL_RECIPIENTS: ${{ secrets.EMAIL_RECIPIENTS }}
+        THEMIS_EMAIL_RECIPIENTS: ${{ secrets.THEMIS_EMAIL_RECIPIENTS }}
         LOOKERSDK_BASE_URL: ${{ secrets.LOOKERSDK_BASE_URL }}
         LOOKERSDK_CLIENT_ID: ${{ secrets.LOOKERSDK_CLIENT_ID }}
         LOOKERSDK_CLIENT_SECRET: ${{ secrets.LOOKERSDK_CLIENT_SECRET }}
@@ -33,7 +33,7 @@ jobs:
     - name: Run Themis application
       env:
         SENDGRID_API_KEY: ${{ secrets.SENDGRID_API_KEY }}
-        EMAIL_RECIPIENTS: ${{ secrets.EMAIL_RECIPIENTS }}
+        THEMIS_EMAIL_RECIPIENTS: ${{ secrets.THEMIS_EMAIL_RECIPIENTS }}
         LOOKERSDK_BASE_URL: ${{ secrets.LOOKERSDK_BASE_URL }}
         LOOKERSDK_CLIENT_ID: ${{ secrets.LOOKERSDK_CLIENT_ID }}
         LOOKERSDK_CLIENT_SECRET: ${{ secrets.LOOKERSDK_CLIENT_SECRET }}

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ The application variables for Looker can be configured using the looker.ini file
 
 - `SENDGRID_API_KEY` API key for [SendGrid to send report email](https://app.sendgrid.com/login?redirect_to=%2Fsettings%2Fapi_keys)
 
-- `EMAIL_RECIPIENTS` the list of users that receive Themis' report
+- `THEMIS_EMAIL_RECIPIENTS` the list of users that receive Themis' report
 
 ----------
 

--- a/app.json
+++ b/app.json
@@ -9,11 +9,11 @@
       "description": "A SendGrid API key (find it on https://app.sendgrid.com/settings/api_keys)",
       "required": true
     },
-    "EMAIL_RECIPIENTS": {
+    "THEMIS_EMAIL_RECIPIENTS": {
       "description": "An email address or list of email address for the users to receive the report",
       "required": true
     },
-    "FULL_LOOKML_VALIDATION": {
+    "THEMIS_FULL_LOOKML_VALIDATION": {
       "description": "A True or False value to set the validation all LookML (default is False)",
       "required": false
     },

--- a/docs/GCP_Deployment.md
+++ b/docs/GCP_Deployment.md
@@ -34,7 +34,7 @@ Thanks for using Themis, below is the 11 step list to getting it working!
 
 9. Set up the script variables
 - `$ vi looker.ini`  Create the Looker file for authentication
-- Setting Up Env Var Create environment variables for SENDGRID_API_KEY and EMAIL_RECIPIENTS 
+- Setting Up Env Var Create environment variables for SENDGRID_API_KEY and THEMIS_EMAIL_RECIPIENTS 
 
 10. Run the application
 - `$ python3 main.py`	Runs the application

--- a/modules/send_email.py
+++ b/modules/send_email.py
@@ -12,12 +12,12 @@ def send_report_out(content):
     '''Processes the email content and sends it to recipients thru SendGrid'''
     try:
       # format env variable like: 'example1@mail.com,example2@mail.com'
-        email_list = os.environ.get('EMAIL_RECIPIENTS')
+        email_list = os.environ.get('THEMIS_EMAIL_RECIPIENTS')
         to_emails = []
         for email in email_list.split(','):
           to_emails.append(email)
     except Exception as e:
-        print("Missing EMAIL_RECIPIENTS Variables {}".format(e))
+        print("Missing THEMIS_EMAIL_RECIPIENTS Variables {}".format(e))
 
     message = Mail(
         from_email = 'themisreport@example.com',

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -7,7 +7,7 @@ class LookerSDKTestCase(unittest.TestCase):
     base_url = os.environ.get('LOOKERSDK_BASE_URL')
     api_id = os.environ.get('LOOKERSDK_CLIENT_ID')
     api_secret = os.environ.get('LOOKERSDK_CLIENT_SECRET')
-    email_list = os.environ.get('EMAIL_RECIPIENTS')
+    email_list = os.environ.get('THEMIS_EMAIL_RECIPIENTS')
     sg_key = os.environ.get('SENDGRID_API_KEY')
 
     def test_looker_credentials(self):


### PR DESCRIPTION
Sorry for this annoying first change!

I think the environment variable should be more specific than 'EMAIL_RECIPIENTS' - it's possible another tool might require a variable with the same name. Feel free to ignore this if you want

I've done the same for FULL_LOOKML_VALIDATION --> THEMIS_FULL_LOOKML_VALIDATION.